### PR TITLE
Fix local CMS dev server

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,11 +1,12 @@
 backend:
   name: git-gateway
+  branch: master
 local_backend: true
 media_folder: public/img
 public_folder: img
 
 i18n:
-  structure: single_file
+  structure: multiple_folders
   locales: [en, de]
   default_locale: de
 

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,13 +1,15 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Content Manager</title>
+    <!-- Include the script that enables Netlify Identity on this page. -->
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
-<!-- Include the script that builds the page and powers Netlify CMS -->
-<script src="https://unpkg.com/netlify-cms@2.9.7/dist/netlify-cms.js"></script>
+<!-- Be carefull when updating this to a more recent version. I had it at 2.9. and it gave me a LOT of headaches
+(didn't connect to local server and ignored i18n settings for no obvious reason). -->
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The version of netlify-cms in use previously apparently had a lot of bugs. This PR downgrades it which makes the workflow with netlify-cms-proxy-server as well as i18n work. Yey! Fixes #9 